### PR TITLE
Add Jacoco XML plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A sonar image containing plugins and quality profiles used at ICTU
 
 ## Building and running locally
 
-    docker build . -t ictusonar
+    docker build -f Dockerfile-community-edition -t ictusonar .
     docker run -it -p 9000:9000 ictusonar
     browse to http://localhost:9000
 

--- a/plugins/plugin-list
+++ b/plugins/plugin-list
@@ -1,4 +1,5 @@
 https://binaries.sonarsource.com/Distribution/sonar-csharp-plugin/sonar-csharp-plugin-7.15.0.8572.jar
+https://binaries.sonarsource.com/Distribution/sonar-jacoco-plugin/sonar-jacoco-plugin-1.0.2.475.jar
 https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-5.13.1.18282.jar
 https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-5.2.1.7778.jar
 https://binaries.sonarsource.com/Distribution/sonar-html-plugin/sonar-html-plugin-3.1.0.1615.jar


### PR DESCRIPTION
SonarQube is deprecating importing code coverage from jacoco.exec (see [MMF-1651](https://jira.sonarsource.com/browse/MMF-1651)) and the XML format should be used instead. The [JaCoCo Plugin](https://docs.sonarqube.org/display/PLUG/JaCoCo+Plugin) is required for this, which is added by this pull request. This plugin is also installed by default, but we remove all plugins when building the Docker image.