### PR TITLE
Set additional Java options from environment

### DIFF
--- a/sonar.properties
+++ b/sonar.properties
@@ -10,4 +10,4 @@ ldap.user.emailAttribute=mail
 ldap.group.baseDn=${env:LDAP_GROUP_BASEDN}
 ldap.group.request=(&(objectClass=posixGroup)(memberUid={uid}))
 sonar.python.pylint=/usr/bin/pylint
-
+sonar.search.javaAdditionalOpts=${env:JAVA_ADDITIONAL_OPTS}

--- a/start-with-profile.sh
+++ b/start-with-profile.sh
@@ -187,6 +187,8 @@ fi
 
 # explicitely set LDAP_REALM to prevent error when starting Sonar without LDAP settings
 export LDAP_REALM=${LDAP_REALM}
+# explicitely set JAVA_ADDITIONAL_OPTS to prevent error when starting Sonar
+export JAVA_ADDITIONAL_OPTS="${JAVA_ADDITIONAL_OPTS}"
 
 # Start Sonar
 ./bin/run.sh &


### PR DESCRIPTION
We need to set `sonar.search.javaAdditionalOpts` property and now use our own image. This PR makes it an option in this image so we can use the original ICTU image and upgrade more easily.