### PR TITLE
Add Sonar auth OpenID connect plugin

### DIFF
--- a/plugins/plugin-list
+++ b/plugins/plugin-list
@@ -16,3 +16,4 @@ https://github.com/jensgerdes/sonar-pmd/releases/download/3.2.1/sonar-pmd-plugin
 https://github.com/sbaudoin/sonar-ansible/releases/download/v2.3.0/sonar-ansible-plugin-2.3.0.jar
 https://github.com/sbaudoin/sonar-yaml/releases/download/v1.5.1/sonar-yaml-plugin-1.5.1.jar
 https://github.com/spotbugs/sonar-findbugs/releases/download/4.0.0/sonar-findbugs-plugin-4.0.0.jar
+https://github.com/vaulttec/sonar-auth-oidc/releases/download/v2.0.0/sonar-auth-oidc-plugin-2.0.0.jar


### PR DESCRIPTION
We use the OpenID connect plugin to connect with the platform's IdP.