### PR TITLE
Add and use java-cacerts to use Mozilla CA list instead of Oracle

### DIFF
--- a/Dockerfile-community-edition
+++ b/Dockerfile-community-edition
@@ -1,6 +1,7 @@
 FROM sonarqube:8.3.1-community
 USER root
-RUN apk add --no-cache wget curl jq
+RUN apk add --no-cache wget curl java-cacerts jq
+RUN ln -sf /etc/ssl/certs/java/cacerts /opt/java/openjdk/lib/security/cacerts
 ADD ./plugins /tmp/plugins
 RUN rm -rf ./extensions/plugins/* && \
     cat /tmp/plugins/plugin-list && \

--- a/Dockerfile-developer-edition
+++ b/Dockerfile-developer-edition
@@ -1,6 +1,7 @@
 FROM sonarqube:8.3.1-developer
 USER root
-RUN apk add --no-cache wget curl jq
+RUN apk add --no-cache wget curl java-cacerts jq
+RUN ln -sf /etc/ssl/certs/java/cacerts /opt/java/openjdk/lib/security/cacerts
 ADD ./plugins /tmp/plugins
 RUN rm -rf ./extensions/plugins/* && \
     cat /tmp/plugins/plugin-list && \


### PR DESCRIPTION
We have added integration with a Keycloak instance with a TLS certificate issued by PKI-Overheid. By default Oracle does not want to include Government CA's. Alpine uses the Mozilla CA list (like all normal Linux distro's). By adding `java-cacerts` and linking to the `cacerts` the system certs are also used within Java (including PKI-Overheid).