### PR TITLE
Use SONAR_JDBC_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Example docker-compose file:
       www:
         image: ictu/sonar:8.6
         environment:
-          - SONARQUBE_JDBC_URL=jdbc:postgresql://db:5432/sonar
+          - SONAR_JDBC_URL=jdbc:postgresql://db:5432/sonar
           - SONAR_JDBC_USERNAME=sonar
           - SONAR_JDBC_PASSWORD=sonar
         ports:
@@ -58,7 +58,7 @@ Otherwise if incorrect credentials are provided Sonarqube will exit.
       - SONAR_CE_JAVAADDITIONALOPTS=-Duser.timezone=Europe/Amsterdam
       - SONAR_SEARCH_JAVAADDITIONALOPTS=-Duser.timezone=Europe/Amsterdam
 
-> Note: The Sonar start script waits for the database to become available (only when using PostgreSQL). DB_START_TIMEOUT (default: 60 seconds) defines how long the script will wait for the database to become available before exiting. Similarly SONAR_START_TIMEOUT (default: 600 seconds) defines how long the script should wait for Sonar to start up. 
+> Note: The Sonar start script waits for the database to become available (only when using PostgreSQL). DB_START_TIMEOUT (default: 60 seconds) defines how long the script will wait for the database to become available before exiting. Similarly SONAR_START_TIMEOUT (default: 600 seconds) defines how long the script should wait for Sonar to start up.
 
 > Note: The docker images are built automatically with circleci and pushed to docker hub when a tag is created.
 

--- a/start-with-profile.sh
+++ b/start-with-profile.sh
@@ -14,7 +14,7 @@ function curlAdmin {
 # Check if the database is ready for connections
 function waitForDatabase {
     # get HOST:PORT from JDBC URL
-    if [[ $SONARQUBE_JDBC_URL =~ postgresql://([^:/]+)(:([0-9]+))?/ ]]; then
+    if [[ $SONAR_JDBC_URL =~ postgresql://([^:/]+)(:([0-9]+))?/ ]]; then
         local host=${BASH_REMATCH[1]}
         local port=${BASH_REMATCH[3]:-5432}
     else
@@ -63,7 +63,7 @@ function waitForSonarUp {
 
 # Try to change the default admin password to the one provided in SONARQUBE_PASSWORD
 function changeDefaultAdminPassword {
-    if [ -n "$SONARQUBE_PASSWORD" ]; then 
+    if [ -n "$SONARQUBE_PASSWORD" ]; then
         echo "Trying to change the default admin password"
         curl -s -X POST -u "admin:admin" -f "$BASE_URL/api/users/change_password?login=admin&password=${SONARQUBE_PASSWORD}&previousPassword=admin"
     fi
@@ -201,7 +201,7 @@ function createProfile {
         if [[ $currentProfileName =~ .*EXTENDED$ ]]; then
             echo "Changing parent of extended profile $currentProfileName for language $3 to $profileName"
             curlAdmin -X POST "$BASE_URL/api/qualityprofiles/change_parent?qualityProfile=$currentProfileName&parentQualityProfile=$profileName&language=$3"
-        else 
+        else
             echo "Setting profile $profileName for language $3 as default"
             curlAdmin -X POST "$BASE_URL/api/qualityprofiles/set_default?qualityProfile=$profileName&language=$3"
         fi
@@ -214,7 +214,7 @@ function createProfile {
 BASE_URL=http://127.0.0.1:9000
 
 # waitForDatabase
-if [ "$SONARQUBE_JDBC_URL" ]; then
+if [ "$SONAR_JDBC_URL" ]; then
   waitForDatabase
 fi
 


### PR DESCRIPTION
I noticed you were using `SONAR_JDBC_USERNAME` instead of `SONARQUBE_JDBC_USERNAME` for the `pg_isready`. Seems that the `SONAR_` is newer and the `SONARQUBE_` is deprecated. See https://community.sonarsource.com/t/container-image-database-configuration/21039/2

This MR also changes that for `JDBC_URL`.

I didn't do `SONARQUBE_USERNAME`, `SONARQUBE_PASSWORD` and `SONARQUBE_TOKEN` as these are our own custom environment variables.