### PR TITLE
Replace HQ with Quality-time

### DIFF
--- a/rules/cs.txt
+++ b/rules/cs.txt
@@ -1,10 +1,10 @@
-+common-cs:DuplicatedBlocks     # NOT used by HQ
-+csharpsquid:S104               # NCSS; used by HQ
-+csharpsquid:S107|max=5         # Too many parameters; used by HQ
-+csharpsquid:S125               # Commented code; used by HQ
-+csharpsquid:S134               # Depth of nesting; NOT used by HQ
-+csharpsquid:S1067              # Too complex expression; NOT used by HQ
-+csharpsquid:S1309              # Violation suppression; used by HQ
-+csharpsquid:S1541|max=10       # Methods and properties too complex; used by HQ
++common-cs:DuplicatedBlocks  # NOT used by Quality-time
++csharpsquid:S104            # NCSS; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#long-units-from-sonarqube)
++csharpsquid:S107|max=5      # Too many parameters; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#many-parameters-from-sonarqube)
++csharpsquid:S125            # Commented code; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#commented-out-code-from-sonarqube)
++csharpsquid:S134            # Depth of nesting; NOT used by Quality-time
++csharpsquid:S1067           # Too complex expression; NOT used by Quality-time
++csharpsquid:S1309           # Violation suppression; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#suppressed-violations-from-sonarqube)
++csharpsquid:S1541|max=10    # Methods and properties too complex; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#complex-units-from-sonarqube)
 #end please ensure every rule ends with a new line character
 

--- a/rules/java.txt
+++ b/rules/java.txt
@@ -1,12 +1,12 @@
-+java:S1541|Threshold=10                            # Used by HQ
-+java:NoSonar                                       # Used by HQ to report on suppressed violations
-+java:S1309                                         # Used by HQ to report on suppressed violations
-+java:S1310                                         # Used by HQ to report on suppressed violations
-+java:S1315                                         # Used by HQ to report on suppressed violations
-+java:S1067                                         # Expression too complex; NOT used by HQ
-+java:S109                                          # Magic numbers; NOT used by HQ
-+java:S138|max=20                                   # Methods with too many lines; used by HQ
-+java:S107|max=5                                    # Too many parameters; used by HQ
-+java:S125                                          # Used by HQ
++java:S1541|Threshold=10  # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#complex-units-from-sonarqube)
++java:NoSonar             # Used by Quality-time to report on suppressed violations (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#suppressed-violations-from-sonarqube)
++java:S1309               # Used by Quality-time to report on suppressed violations (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#suppressed-violations-from-sonarqube)
++java:S1310               # Used by Quality-time to report on suppressed violations (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#suppressed-violations-from-sonarqube)
++java:S1315               # Used by Quality-time to report on suppressed violations (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#suppressed-violations-from-sonarqube)
++java:S1067               # Expression too complex; NOT used by Quality-time
++java:S109                # Magic numbers; NOT used by Quality-time
++java:S138|max=20         # Methods with too many lines; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#long-units-from-sonarqube)
++java:S107|max=5          # Too many parameters; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#many-parameters-from-sonarqube)
++java:S125                # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#commented-out-code-from-sonarqube)
 #end please ensure every rule ends with a new line character
 

--- a/rules/js.txt
+++ b/rules/js.txt
@@ -1,9 +1,9 @@
-+javascript:S1541|maximumFunctionComplexityThreshold=10                 # Used by HQ
-+javascript:S134                                                        # NOT used by HQ
-+javascript:S1067                                                       # Expression too complex; NOT used by HQ
-+javascript:S106                                                        # Console logging should not be used; NOT used by HQ
-+javascript:S107|maximumFunctionParameters=5                            # Used by HQ
-+javascript:S125                                                        # Used by HQ
++javascript:S1541|maximumFunctionComplexityThreshold=10  # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#complex-units-from-sonarqube)
++javascript:S134                                         # NOT used by Quality-time
++javascript:S1067                                        # Expression too complex; NOT used by Quality-time
++javascript:S106                                         # Console logging should not be used; NOT used by Quality-time
++javascript:S107|maximumFunctionParameters=5             # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#many-parameters-from-sonarqube)
++javascript:S125                                         # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#commented-out-code-from-sonarqube)
 # Missing: NoSonar, NCSS, Parameters
 #end please ensure every rule ends with a new line character
 

--- a/rules/py.txt
+++ b/rules/py.txt
@@ -1,11 +1,11 @@
-+common-py:DuplicatedBlocks                                         # NOT used by HQ
-+python:S104                                                        # Too many lines of code in file; NOT used by HQ
-+python:S107|max=5                                                  # Too many parameters; used by HQ
-+python:S125                                                        # Commented code; used by HQ
-+python:S134                                                        # Too deep nesting; NOT used by HQ
-+Pylint:R0915                                                       # Too many statements; used by HQ
-+Pylint:I0011                                                       # Locally disable message, NoSonar alternative; used by HQ
-+Pylint:I0020                                                       # Suppressed message, NoSonar alternative; used by HQ
-+python:FunctionComplexity|maximumFunctionComplexityThreshold=10    # Used by HQ
++common-py:DuplicatedBlocks                                       # NOT used by Quality-time
++python:S104                                                      # Too many lines of code in file; NOT used by Quality-time
++python:S107|max=5                                                # Too many parameters; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#many-parameters-from-sonarqube)
++python:S125                                                      # Commented code; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#commented-out-code-from-sonarqube)
++python:S134                                                      # Too deep nesting; NOT used by Quality-time
++Pylint:R0915                                                     # Too many statements; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#long-units-from-sonarqube)
++Pylint:I0011                                                     # Locally disable message, NoSonar alternative; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#suppressed-violations-from-sonarqube)
++Pylint:I0020                                                     # Suppressed message, NoSonar alternative; used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#suppressed-violations-from-sonarqube)
++python:FunctionComplexity|maximumFunctionComplexityThreshold=10  # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#complex-units-from-sonarqube)
 #end please ensure every rule ends with a new line character
 

--- a/rules/ts.txt
+++ b/rules/ts.txt
@@ -1,8 +1,8 @@
-+common-ts:DuplicatedBlocks             # NOT used by HQ
-+typescript:S109                        # Magic number; NOT used by HQ
-+typescript:S104                        # File length; NOT used by HQ
-+typescript:S106                        # Console logging; NOT used by HQ
-+typescript:S1541|Treshold=10           # Used by HQ
--typescript:S4328                       # reason: the rule does not recognize 'local' imports
++common-ts:DuplicatedBlocks    # NOT used by Quality-time
++typescript:S109               # Magic number; NOT used by Quality-time
++typescript:S104               # File length; NOT used by Quality-time
++typescript:S106               # Console logging; NOT used by Quality-time
++typescript:S1541|Treshold=10  # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#complex-units-from-sonarqube)
+-typescript:S4328              # reason: the rule does not recognize 'local' imports
 #end please ensure every rule ends with a new line character
 

--- a/rules/vbnet.txt
+++ b/rules/vbnet.txt
@@ -1,4 +1,4 @@
-+vbnet:S1541  # Too complex function, procedure or property; Used by HQ
++vbnet:S1541  # Too complex function, procedure or property; Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#complex-units-from-sonarqube)
 # Missing: method length, NoSonar, too many parameters, commented loc
 #end please ensure every rule ends with a new line character
 

--- a/rules/web.txt
+++ b/rules/web.txt
@@ -1,6 +1,6 @@
-+common-web:DuplicatedBlocks    # NOT used by HQ
-+Web:ComplexityCheck            # Used by HQ
-+Web:LongJavaScriptCheck        # Used by HQ
-+Web:AvoidCommentedOutCodeCheck # Used by HQ
++common-web:DuplicatedBlocks     # NOT used by Quality-time
++Web:ComplexityCheck             # NOT used by Quality-time (but will be in a future version, check: https://github.com/ICTU/quality-time/issues/2137)
++Web:LongJavaScriptCheck         # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#long-units-from-sonarqube)
++Web:AvoidCommentedOutCodeCheck  # Used by Quality-time (https://github.com/ICTU/quality-time/blob/master/docs/METRICS_AND_SOURCES.md#commented-out-code-from-sonarqube)
 #end please ensure every rule ends with a new line character
 


### PR DESCRIPTION
This PR:
- Replaces HQ with Quality-time in the comments of the rules files.
- Adds links to Quality-time documentation that lists which SonarQube rules Quality-time uses for specific metrics. 
- Indents the comments consistently (two spaces after the widest rule definition).